### PR TITLE
テストファイルの自動作成スクリプト

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Configure cmake
         run: cmake -B build
       - name: Run clang-tidy
-        run: clang-tidy -p build -warnings-as-errors '*,-clang-diagnostic-unused-parameter' $(git ls-files '*.cpp' '*.hpp')
+        run: clang-tidy -p build -warnings-as-errors '*,-clang-diagnostic-unused-parameter' $(git ls-files '*.cpp' '*.hpp' | grep -v '^scripts/template/')

--- a/scripts/add_test.sh
+++ b/scripts/add_test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Get the absolute path
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+project_root=$(dirname "$script_dir")
+
+# Prompt user for test name (in snake_case)
+read -r -p "Enter the name of the test (in snake_case): " test_name
+if [ -z "$test_name" ]; then
+  echo "Test name cannot be empty!"
+  exit 1
+fi
+
+# Normalize the test name like "foo_test"
+test_name=${test_name%.cpp} # Remove .cpp extension if present
+if [[ ! $test_name == *_test ]]; then
+  test_name="${test_name}_test" # Add _test suffix if NOT present
+fi
+
+# Set the path for the test file
+test_file="$project_root/tests/${test_name}.cpp"
+relative_test_file="tests/${test_name}.cpp"
+
+# Check if the test file already exists
+if [ -f "$test_file" ]; then
+  echo "Test file already exists!"
+  exit 0
+fi
+
+# Create the test file and copy the template
+cp "$script_dir/template/test_template.cpp" "$test_file"
+
+# Set the path for the CMakeLists.txt file
+cmake_file="$project_root/tests/CMakeLists.txt"
+relative_cmake_file="tests/CMakeLists.txt"
+
+# Append to CMakeLists.txt
+echo >>"$cmake_file"
+echo "add_executable(${test_name} ${test_name}.cpp)" >>"$cmake_file"
+echo "gtest_discover_tests(${test_name})" >>"$cmake_file"
+
+# Print the success message
+echo "Test added successfully!"
+
+# Display the list of changed files in a git-like format
+echo ""
+echo "Changes:"
+echo "  A $relative_test_file"
+echo "  M $relative_cmake_file"

--- a/scripts/template/test_template.cpp
+++ b/scripts/template/test_template.cpp
@@ -1,0 +1,8 @@
+#include <fakeit.hpp>
+#include <gtest/gtest.h>
+
+using namespace fakeit;
+
+TEST(TestTemplate, test) {
+    EXPECT_EQ(1, 1);
+}


### PR DESCRIPTION
#92 

`scripts/add_test.sh` でテストファイルの準備ができるようになりました.
実行例:
```bash
$ scripts/add_test.sh
Enter the name of the test (in snake_case): foo_test
Test added successfully!

Changes:
  A tests/foo_test.cpp
  M tests/CMakeLists.txt

```

細かい処理として
- テスト名が空だったら何もしない
- 作成対象のテストファイルが既に存在していたら何もしない
- テストの名前は `foo_test` の形式に正規化されます
    - プロンプトに `foo_test`, `foo_test.cpp`, `foo`, `foo.cpp` のどれを入力しても, 作られるテストの名前は `foo_test` になります。
    - `foo.cpp` だけは `foo` にしても良かったのですが, ファイル名を統一してもらうために強制的に正規化しています