### PR TITLE
リリースビルドができない問題を修正

### DIFF
--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -39,7 +39,7 @@ jobs:
           create-symlink: true
 
       - name: Configure CMake
-        run: cmake -B build -G Ninja ${{ matrix.cmake-args }}
+        run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug ${{ matrix.cmake-args }}
 
       - name: Build
         run: cmake --build build -j

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 project(webserv)
 
-set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_CXX_STANDARD 98)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")


### PR DESCRIPTION
#89 

デバッグビルド、リリースビルドを使い分けられるようになった。CI はデバッグビルドを行う。
```bash
$ cmake -B build-debug -DCMAKE_BUILD_TYPE=Debug
# 省略

$ cat build-debug/CMakeFiles/webserv.dir/flags.make  # 適切なフラグが付いているか
# CMAKE generated file: DO NOT EDIT!
# Generated by "Unix Makefiles" Generator, CMake Version 3.28s    flags.make            progress.make                             

# compile CXX with /opt/homebrew/opt/llvm/bin/clang++
CXX_DEFINES = 

CXX_INCLUDES = -I/Users/kmizuki/Documents/42/webserv/internal

CXX_FLAGSarm64 =  -Wall -Wextra -g -O0 -fsanitize=address,undefined --coverage -std=gnu++98 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk

CXX_FLAGS =  -Wall -Wextra -g -O0 -fsanitize=address,undefined --coverage -std=gnu++98 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk

$ cmake -B build-release -DCMAKE_BUILD_TYPE=Release
# 省略

$ cat build-release/CMakeFiles/webserv.dir/flags.make  # 適切なフラグが付いているか
# CMAKE generated file: DO NOT EDIT!
# Generated by "Unix Makefiles" Generator, CMake Version 3.28s    flags.make            progress.make                             

# compile CXX with /opt/homebrew/opt/llvm/bin/clang++
CXX_DEFINES = 

CXX_INCLUDES = -I/Users/kmizuki/Documents/42/webserv/internal

CXX_FLAGSarm64 =  -Wall -Wextra -O3 -DNDEBUG -std=gnu++98 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk

CXX_FLAGS =  -Wall -Wextra -O3 -DNDEBUG -std=gnu++98 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk

```